### PR TITLE
Feature/service name retry

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/Nordstrom/ctrace-go/ext"
@@ -82,6 +83,9 @@ func TracedHandler(h http.Handler, options ...Option) http.Handler {
 		)
 		h.ServeHTTP(httpsnoop.Wrap(w, hooks), wr)
 		span.SetTag(ext.HTTPStatusCodeKey, status)
+
+		serviceName := os.Getenv("SERVICENAME")
+		span.SetTag("serviceName", serviceName)
 
 		if status >= 400 {
 			span.SetTag(ext.ErrorKey, true)

--- a/http/server.go
+++ b/http/server.go
@@ -84,8 +84,8 @@ func TracedHandler(h http.Handler, options ...Option) http.Handler {
 		h.ServeHTTP(httpsnoop.Wrap(w, hooks), wr)
 		span.SetTag(ext.HTTPStatusCodeKey, status)
 
-		serviceName := os.Getenv("SERVICENAME")
-		span.SetTag("serviceName", serviceName)
+		serviceName := os.Getenv("CTRACE_SERVICE_NAME")
+		span.SetTag("service", serviceName)
 
 		if status >= 400 {
 			span.SetTag(ext.ErrorKey, true)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -116,8 +116,8 @@ var _ = Describe("TracedHandler", func() {
 		})
 
 		It("records ServiceName when environment variable is set", func() {
-			os.Setenv("SERVICENAME", "some-service")
-			defer os.Unsetenv("SERVICENAME")
+			os.Setenv("CTRACE_SERVICE_NAME", "some-service")
+			defer os.Unsetenv("CTRACE_SERVICE_NAME")
 			mux.Handle(
 				"/test/",
 				TracedHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
@@ -125,7 +125,7 @@ var _ = Describe("TracedHandler", func() {
 
 			srv = httptest.NewServer(mux)
 			http.Get(srv.URL + "/test/foo")
-			Ω(tr.FinishedSpans()[0].Tag("serviceName")).Should(Equal("some-service"))
+			Ω(tr.FinishedSpans()[0].Tag("service")).Should(Equal("some-service"))
 		})
 	})
 
@@ -161,8 +161,8 @@ var _ = Describe("TracedHandler", func() {
 		})
 
 		It("records ServiceName when environment variable is set", func() {
-			os.Setenv("SERVICENAME", "some-service")
-			defer os.Unsetenv("SERVICENAME")
+			os.Setenv("CTRACE_SERVICE_NAME", "some-service")
+			defer os.Unsetenv("CTRACE_SERVICE_NAME")
 			mux.Handle(
 				"/test/",
 				TracedHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
@@ -170,7 +170,7 @@ var _ = Describe("TracedHandler", func() {
 
 			srv = httptest.NewServer(mux)
 			http.Get(srv.URL + "/test/foo")
-			Ω(tr.FinishedSpans()[0].Tag("serviceName")).Should(Equal("some-service"))
+			Ω(tr.FinishedSpans()[0].Tag("service")).Should(Equal("some-service"))
 		})
 	})
 })


### PR DESCRIPTION
This PR supersedes https://github.com/Nordstrom/ctrace-go/pull/5.

When using the TracedHandler, opentracing.StartSpanFromContext() is used (https://github.com/Nordstrom/ctrace-go/blob/master/http/server.go#L35). This span never gets the additional service tag based on CTRACE_SERVICE_NAME.

This PR addresses this.